### PR TITLE
Fixed 'subtract with overflow' panic when the volume is set to 100

### DIFF
--- a/mdrop/src/volume.rs
+++ b/mdrop/src/volume.rs
@@ -12,8 +12,9 @@ impl Volume {
         Self(level)
     }
     pub fn to_payload(&self) -> u8 {
-        let v = (VOLUME_MIN as u32 - self.0 * VOLUME_MIN as u32 / 100) as u8 - 1;
-        v.clamp(VOLUME_MAX, VOLUME_MIN)
+        let level = self.0.min(100);
+        let v = VOLUME_MIN as u32 - (level * VOLUME_MIN as u32).div_ceil(100);
+        (v as u8).clamp(VOLUME_MAX, VOLUME_MIN)
     }
 
     pub fn from_payload(value: u8) -> Self {


### PR DESCRIPTION
This fixes the overflow panic when the volume is set to 100.

```
./target/debug/mdrop set volume 100
thread 'main' panicked at mdrop/src/volume.rs:15:17:
attempt to subtract with overflow
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```